### PR TITLE
fix: put node_modules/.bin on PATH so totem works in Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "remoteEnv": {
     "PATH": "${containerWorkspaceFolder}/node_modules/.bin:${containerEnv:PATH}"
   },
-  "postCreateCommand": "corepack enable && pnpm install && (git fetch --unshallow 2>/dev/null; git reset HEAD~1 && git add -A || true) && echo '\n🎯 Totem Playground ready!\nRun: totem lint --staged\n'",
+  "postCreateCommand": "corepack enable && pnpm install && (git fetch --unshallow 2>/dev/null || true) && git reset HEAD~1 && git add -A && echo '\n🎯 Totem Playground ready!\nRun: totem lint --staged\n'",
   "customizations": {
     "vscode": {
       "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 {
   "name": "Totem Playground",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
-  "postCreateCommand": "corepack enable && pnpm install && git fetch --unshallow 2>/dev/null; git reset HEAD~1 && git add -A && echo '\n🎯 Totem Playground ready!\nRun: pnpm exec totem lint --staged\n'",
+  "remoteEnv": {
+    "PATH": "${containerEnv:PATH}:${containerWorkspaceFolder}/node_modules/.bin"
+  },
+  "postCreateCommand": "corepack enable && pnpm install && git fetch --unshallow 2>/dev/null; git reset HEAD~1 && git add -A && echo '\n🎯 Totem Playground ready!\nRun: totem lint --staged\n'",
   "customizations": {
     "vscode": {
       "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,9 @@
   "name": "Totem Playground",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
   "remoteEnv": {
-    "PATH": "${containerEnv:PATH}:${containerWorkspaceFolder}/node_modules/.bin"
+    "PATH": "${containerWorkspaceFolder}/node_modules/.bin:${containerEnv:PATH}"
   },
-  "postCreateCommand": "corepack enable && pnpm install && git fetch --unshallow 2>/dev/null; git reset HEAD~1 && git add -A && echo '\n🎯 Totem Playground ready!\nRun: totem lint --staged\n'",
+  "postCreateCommand": "corepack enable && pnpm install && (git fetch --unshallow 2>/dev/null; git reset HEAD~1 && git add -A || true) && echo '\n🎯 Totem Playground ready!\nRun: totem lint --staged\n'",
   "customizations": {
     "vscode": {
       "settings": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@mmnto/cli": "^1.14.0",
-    "@mmnto/mcp": "^1.14.0",
-    "@mmnto/totem": "^1.14.0",
+    "@mmnto/cli": "^1.14.5",
+    "@mmnto/mcp": "^1.14.5",
+    "@mmnto/totem": "^1.14.5",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "typescript": "^5.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,14 +20,14 @@ dependencies:
 
 devDependencies:
   '@mmnto/cli':
-    specifier: ^1.14.0
-    version: 1.14.0(@google/genai@1.48.0)
+    specifier: ^1.14.5
+    version: 1.14.5(@google/genai@1.48.0)
   '@mmnto/mcp':
-    specifier: ^1.14.0
-    version: 1.14.0(@google/genai@1.48.0)
+    specifier: ^1.14.5
+    version: 1.14.5(@google/genai@1.48.0)
   '@mmnto/totem':
-    specifier: ^1.14.0
-    version: 1.14.0(@google/genai@1.48.0)
+    specifier: ^1.14.5
+    version: 1.14.5(@google/genai@1.48.0)
   '@types/node':
     specifier: ^22.0.0
     version: 22.19.17
@@ -508,8 +508,8 @@ packages:
       '@lancedb/lancedb-win32-x64-msvc': 0.26.2
     dev: true
 
-  /@mmnto/cli@1.14.0(@google/genai@1.48.0):
-    resolution: {integrity: sha512-AytJAH12Rhb129cAr6WzP2cSfl1HD5rtwus0bcWoY+Rm2+dfujizjkC1akTjx55UXXcRjCjC5czvqKKdBOb1oA==}
+  /@mmnto/cli@1.14.5(@google/genai@1.48.0):
+    resolution: {integrity: sha512-U2qEFi+hIduIwcJL+VCnRx+2NQFzowiVcYNsA0gK+kCJkoZZRasCLUMRB0dfHInh59SOYgorZ5fpHOUG94fdoQ==}
     hasBin: true
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.50.0'
@@ -525,7 +525,7 @@ packages:
     dependencies:
       '@clack/prompts': 1.2.0
       '@google/genai': 1.48.0
-      '@mmnto/totem': 1.14.0(@google/genai@1.48.0)
+      '@mmnto/totem': 1.14.5(@google/genai@1.48.0)
       commander: 13.1.0
       dotenv: 16.6.1
       jiti: 2.6.1
@@ -541,11 +541,11 @@ packages:
       - ws
     dev: true
 
-  /@mmnto/mcp@1.14.0(@google/genai@1.48.0):
-    resolution: {integrity: sha512-uBoF3POZRmA4+uM4YU5/uoxN7qjXrzTKkRPHTVaFRxN8rK0AmmLDWRg9FRWWSSCtDXFPg6vDq27T7P52wAs6UQ==}
+  /@mmnto/mcp@1.14.5(@google/genai@1.48.0):
+    resolution: {integrity: sha512-SDMmeMg4FvY9k8b9094RE4bVWO5DVqhT4RgTnLH8kKUl3pmvejOj0cr9UMwZzPSGQ9djG80iqOzZKB/T7SQEiw==}
     hasBin: true
     dependencies:
-      '@mmnto/totem': 1.14.0(@google/genai@1.48.0)
+      '@mmnto/totem': 1.14.5(@google/genai@1.48.0)
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       dotenv: 16.6.1
       jiti: 2.6.1
@@ -559,8 +559,8 @@ packages:
       - ws
     dev: true
 
-  /@mmnto/totem@1.14.0(@google/genai@1.48.0):
-    resolution: {integrity: sha512-k+ibTq/T4mraIQQXi3oqLwdwd5p+br4tPLfVHb01FJbDAylVTr9TrYuWXO2m/Z+EZ+vQQ21SbeJYFiv9MoIdiA==}
+  /@mmnto/totem@1.14.5(@google/genai@1.48.0):
+    resolution: {integrity: sha512-KvZMybythPPi2PzqRXknIopZTAfpcc4xxYE/IOfZpaGOFfD0VSYreHfjQWcKP70GbUL5zqoigqlqarn/41Efsw==}
     peerDependencies:
       '@google/genai': '>=1.0.0'
     peerDependenciesMeta:
@@ -571,6 +571,7 @@ packages:
       '@google/genai': 1.48.0
       '@lancedb/lancedb': 0.26.2(apache-arrow@17.0.0)
       apache-arrow: 17.0.0
+      cross-spawn: 7.0.6
       glob: 11.1.0
       openai: 4.104.0(zod@3.25.76)
       remark-frontmatter: 5.0.0


### PR DESCRIPTION
## Summary
- Added `remoteEnv` to devcontainer.json to put `node_modules/.bin` on PATH in every Codespace terminal
- Bare `totem lint --staged` now works without the `pnpm exec` prefix
- Updated the post-create echo message to match

## Test plan
- [ ] Open a new Codespace from this branch
- [ ] Verify `totem lint --staged` works without `pnpm exec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Dev container now prioritizes workspace-installed tooling so local binaries are used by default.
  * Setup message simplifies the displayed lint command for clarity.
  * Initial setup tolerates certain git steps failing without aborting the overall setup.
  * Bumped development tooling to newer patch versions for improved behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->