### PR TITLE
fix: symlink totem into /usr/local/bin for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,7 @@
 {
   "name": "Totem Playground",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
-  "remoteEnv": {
-    "PATH": "${containerWorkspaceFolder}/node_modules/.bin:${containerEnv:PATH}"
-  },
-  "postCreateCommand": "corepack enable && pnpm install && (git fetch --unshallow 2>/dev/null || true) && git reset HEAD~1 && git add -A && echo '\n🎯 Totem Playground ready!\nRun: totem lint --staged\n'",
+  "postCreateCommand": "corepack enable && pnpm install && ln -sf $(pwd)/node_modules/.bin/totem /usr/local/bin/totem && ln -sf $(pwd)/node_modules/.bin/totem-mcp /usr/local/bin/totem-mcp && (git fetch --unshallow 2>/dev/null || true) && git reset HEAD~1 && git add -A && echo '\n🎯 Totem Playground ready!\nRun: totem lint --staged\n'",
   "customizations": {
     "vscode": {
       "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Totem Playground",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
-  "postCreateCommand": "corepack enable && pnpm install && ln -sf $(pwd)/node_modules/.bin/totem /usr/local/bin/totem && ln -sf $(pwd)/node_modules/.bin/totem-mcp /usr/local/bin/totem-mcp && (git fetch --unshallow 2>/dev/null || true) && git reset HEAD~1 && git add -A && echo '\n🎯 Totem Playground ready!\nRun: totem lint --staged\n'",
+  "postCreateCommand": "corepack enable && pnpm install && sudo ln -sf \"${PWD}/node_modules/.bin/totem\" /usr/local/bin/totem && sudo ln -sf \"${PWD}/node_modules/.bin/totem-mcp\" /usr/local/bin/totem-mcp && (git fetch --unshallow 2>/dev/null || true) && git reset HEAD~1 && git add -A && echo '\n🎯 Totem Playground ready!\nRun: totem lint --staged\n'",
   "customizations": {
     "vscode": {
       "settings": {


### PR DESCRIPTION
## Summary
- Replaces `remoteEnv` PATH approach (didn't survive shell profile re-sourcing) with symlinks into `/usr/local/bin`
- Symlinks `totem` and `totem-mcp` during `postCreateCommand` so they're always on PATH

Follows up on #47 which identified the right problem but used `remoteEnv` which gets overridden by `.bashrc`.

## Test plan
- [ ] Open a fresh Codespace from this branch
- [ ] Verify `totem lint --staged` works directly
- [ ] Verify `which totem` resolves to `/usr/local/bin/totem`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development environment setup to make local CLI tools available as global executables during container setup, ensuring commands are runnable without adding local bin paths.
  * Adjusted startup steps to rely on symlinked global executables and retained existing repository initialization messages and fallback fetch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->