### PR TITLE
fix: sudo corepack enable — root cause of broken Codespace demo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Totem Playground",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
-  "postCreateCommand": "sudo corepack enable && pnpm install && sudo ln -sf \"${PWD}/node_modules/.bin/totem\" /usr/local/bin/totem && sudo ln -sf \"${PWD}/node_modules/.bin/totem-mcp\" /usr/local/bin/totem-mcp && (git fetch --unshallow 2>/dev/null || true) && git reset HEAD~1 && git add -A && echo '\n🎯 Totem Playground ready!\nRun: totem lint --staged\n'",
+  "postCreateCommand": "sudo corepack enable && pnpm install && echo \"export PATH=\\\"${PWD}/node_modules/.bin:\\$PATH\\\"\" >> ~/.bashrc && (git fetch --unshallow 2>/dev/null || true) && git reset HEAD~1 && git add -A && echo '\n🎯 Totem Playground ready!\nRun: totem lint --staged\n'",
   "customizations": {
     "vscode": {
       "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Totem Playground",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
-  "postCreateCommand": "corepack enable && pnpm install && sudo ln -sf \"${PWD}/node_modules/.bin/totem\" /usr/local/bin/totem && sudo ln -sf \"${PWD}/node_modules/.bin/totem-mcp\" /usr/local/bin/totem-mcp && (git fetch --unshallow 2>/dev/null || true) && git reset HEAD~1 && git add -A && echo '\n🎯 Totem Playground ready!\nRun: totem lint --staged\n'",
+  "postCreateCommand": "sudo corepack enable && pnpm install && sudo ln -sf \"${PWD}/node_modules/.bin/totem\" /usr/local/bin/totem && sudo ln -sf \"${PWD}/node_modules/.bin/totem-mcp\" /usr/local/bin/totem-mcp && (git fetch --unshallow 2>/dev/null || true) && git reset HEAD~1 && git add -A && echo '\n🎯 Totem Playground ready!\nRun: totem lint --staged\n'",
   "customizations": {
     "vscode": {
       "settings": {


### PR DESCRIPTION
## Summary
- `corepack enable` needs `sudo` on the `javascript-node:22` image (it symlinks into `/usr/local/bin` which is root-owned)
- Without it, the entire `postCreateCommand` chain fails silently — no pnpm, no install, no totem binary
- This was the root cause behind #47 and #48; those PRs addressed real issues (PATH order, symlinks) but couldn't help because the chain never got past the first command

## Test plan
- [ ] Open a fresh Codespace from this branch
- [ ] Verify `totem lint --staged` works directly
- [ ] Verify the "Totem Playground ready!" message appears in the creation log

## Quick validation in existing Codespace
```bash
sudo corepack enable && pnpm install && sudo ln -sf "${PWD}/node_modules/.bin/totem" /usr/local/bin/totem
totem lint --staged
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Dev container now enables corepack with elevated privileges.
  * Stops creating system-wide symlinks for local tooling.
  * Ensures node_modules/.bin is appended to PATH so local binaries are available in the shell.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->