### PR TITLE
fix: use pnpm in CI workflow and /etc/profile.d for Codespace PATH

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Totem Playground",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
-  "postCreateCommand": "sudo corepack enable && pnpm install && echo \"export PATH=\\\"${PWD}/node_modules/.bin:\\$PATH\\\"\" >> ~/.bashrc && (git fetch --unshallow 2>/dev/null || true) && git reset HEAD~1 && git add -A && echo '\n🎯 Totem Playground ready!\nRun: totem lint --staged\n'",
+  "postCreateCommand": "sudo corepack enable && pnpm install && echo \"export PATH=\\\"${PWD}/node_modules/.bin:\\$PATH\\\"\" | sudo tee /etc/profile.d/totem-path.sh > /dev/null && (git fetch --unshallow 2>/dev/null || true) && git reset HEAD~1 && git add -A && echo '\n🎯 Totem Playground ready!\nRun: totem lint --staged\n'",
   "customizations": {
     "vscode": {
       "settings": {

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,11 +19,14 @@ jobs:
         with:
           node-version: 22
 
+      - name: Install pnpm
+        run: corepack enable
+
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Install latest @mmnto packages
-        run: npm install --no-save @mmnto/cli@latest @mmnto/totem@latest
+        run: pnpm add --save-dev @mmnto/cli@latest @mmnto/totem@latest
 
       # ── Entity / import tests (no git state needed) ──
       - name: Run entity & import tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install latest @mmnto packages
-        run: pnpm add --save-dev @mmnto/cli@latest @mmnto/totem@latest
+        run: |
+          pnpm add --save-dev @mmnto/cli@latest @mmnto/totem@latest
+          git restore --worktree --staged package.json pnpm-lock.yaml
 
       # ── Entity / import tests (no git state needed) ──
       - name: Run entity & import tests


### PR DESCRIPTION
## Summary
- **CI**: Replace `npm ci` with `corepack enable` + `pnpm install --frozen-lockfile`. This project uses pnpm — there has never been a `package-lock.json`, so `npm ci` has been failing every night for 10+ days.
- **Codespace**: Write PATH export to `/etc/profile.d/totem-path.sh` instead of `~/.bashrc`. The Node 22 devcontainer image defaults to zsh, which doesn't source `.bashrc`.

## Test plan
- [ ] Open a fresh Codespace from this branch — verify `totem lint --staged` works
- [ ] Trigger the nightly workflow manually — verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development environment setup to apply PATH changes system-wide for all shells.
  * Migrated CI pipeline to pnpm-based dependency management with lockfile-enforced installs for more reproducible builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->