### PR TITLE
fix: use orphan baseline for Codespace demo + align README command

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Totem Playground",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
-  "postCreateCommand": "sudo corepack enable && pnpm install && git fetch --unshallow 2>/dev/null; git reset HEAD~1 && git add -A && (grep -q 'Totem Playground ready' ~/.bashrc || echo \"echo -e '\\n🎯 Totem Playground ready!\\nRun: pnpm exec totem lint --staged\\n'\" >> ~/.bashrc)",
+  "postCreateCommand": "sudo corepack enable && pnpm install && git checkout --orphan demo && git reset && git add package.json tsconfig.json totem.config.ts src/app/page.tsx src/app/layout.tsx README.md .totem/compiled-rules.json .eslintrc.json && git commit -m baseline --no-verify && git branch -M main && git add src/app/api/ src/lib/ src/middleware/ && (grep -q 'Totem Playground ready' ~/.bashrc || echo \"echo -e '\\n🎯 Totem Playground ready!\\nRun: pnpm exec totem lint --staged\\n'\" >> ~/.bashrc)",
   "customizations": {
     "vscode": {
       "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Totem Playground",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
-  "postCreateCommand": "sudo corepack enable && pnpm install && git checkout --orphan demo && git reset && git add package.json tsconfig.json totem.config.ts src/app/page.tsx src/app/layout.tsx README.md .totem/compiled-rules.json .eslintrc.json && git commit -m baseline --no-verify && git branch -M main && git add src/app/api/ src/lib/ src/middleware/ && (grep -q 'Totem Playground ready' ~/.bashrc || echo \"echo -e '\\n🎯 Totem Playground ready!\\nRun: pnpm exec totem lint --staged\\n'\" >> ~/.bashrc)",
+  "postCreateCommand": "sudo corepack enable && pnpm install && if [ ! -f .git/.totem-demo-baseline ]; then git checkout --orphan demo && git add . && git reset src/app/api/ src/lib/ src/middleware/ && git commit -m baseline --no-verify && git branch -M main && git add src/app/api/ src/lib/ src/middleware/ && touch .git/.totem-demo-baseline; fi && (grep -q 'Totem Playground ready' ~/.bashrc || echo \"echo -e '\\n🎯 Totem Playground ready!\\nRun: pnpm exec totem lint --staged\\n'\" >> ~/.bashrc)",
   "customizations": {
     "vscode": {
       "settings": {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A broken Next.js app with 5 intentional architectural violations. [Totem](https:
 When the terminal opens, run:
 
 ```bash
-totem lint --staged
+pnpm exec totem lint --staged
 ```
 
 ### Or run locally


### PR DESCRIPTION
## Summary
- Replace fragile `git reset HEAD~1` with the same orphan baseline approach used by CI (`setup-baseline.sh`): commit clean files, then stage violation dirs (`src/app/api/`, `src/lib/`, `src/middleware/`)
- Update README "Try It In Your Browser" command from `totem lint --staged` to `pnpm exec totem lint --staged`

The `HEAD~1` rewind only worked when the last commit touched violation files. Any infrastructure PR (like #47-#51) pushed the violation commit deeper, making the demo show 0 violations.

## Test plan
- [ ] Open a fresh Codespace from this branch
- [ ] Verify `pnpm exec totem lint --staged` shows violations
- [ ] Verify the welcome message appears in the terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README to run the lint check via the project's package-manager wrapper for more consistent tooling.

* **Chores**
  * Improved development-container setup to create a clean baseline on first run, enable project tooling, install dependencies, and selectively preserve essential configs and source areas for a ready playground.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->