### PR TITLE
feat: add full Claude Code harness + bump totem to 1.14.6

### DIFF
--- a/.claude/docs/agent-workflow.md
+++ b/.claude/docs/agent-workflow.md
@@ -1,0 +1,54 @@
+# Agent Workflow — Controller/Worker Pattern
+
+## Principle
+
+The main conversation is the **Controller**. It plans, dispatches, reviews, and commits.
+Subagents are **Workers**. They receive a focused task, execute it, and report back.
+
+## When to Delegate
+
+Delegate to a background agent when:
+
+- The task involves writing code + running tests
+- The output would be >5KB of terminal text
+- The task is mechanical (lint, test, format)
+
+Do NOT delegate when:
+
+- The task requires architectural decisions
+- The task needs MCP tool calls (agents can't access MCP)
+- The task needs git push / PR creation
+- The task is a 1-2 line change
+
+## Dispatch Template
+
+When spawning a worker agent, provide:
+
+1. **Files to modify** — exact paths
+2. **What to change** — specific instructions
+3. **Test command** — how to verify
+4. **Report format** — "report success/failure and any errors"
+
+## Review Protocol
+
+When the agent reports back:
+
+1. Read the changed files
+2. Verify changes match the spec
+3. Run `pnpm exec totem lint`
+4. Commit with proper message
+5. Move to next task
+
+## Pre-Push Review
+
+Before pushing, run `/prepush` to lint and review. The review gate hook blocks pushes without a passing review.
+
+## Available Plugins
+
+- `coderabbit:code-review` — CodeRabbit review
+- `coderabbit:autofix` — auto-fix review comments (requires user approval)
+
+## PR Bot Reply Protocol
+
+- **CodeRabbit:** Reply inline to each comment freely.
+- **GCA:** ONE batched comment with `@gemini-code-assist` in the main PR thread. Never reply inline.

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -58,6 +58,6 @@ This makes `totem lint --staged` see the violation files as new staged additions
 
 ## Cross-Repo Context
 
-- **totem** (`D:\Dev\totem`) — the main totem monorepo
-- **totem-strategy** (`D:\Dev\totem-strategy`) — governance, ADRs, journal entries
+- **totem** — the main totem monorepo (sibling directory)
+- **totem-strategy** — governance, ADRs, journal entries (sibling directory)
 - Journal entries for this repo live in `totem-strategy/.journal/totem-playground/`

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -1,0 +1,63 @@
+# Architecture Context
+
+## Repo Purpose
+
+totem-playground is a broken Next.js app with 5 intentional architectural violations. It serves two purposes:
+
+1. **Demo surface** — "Try Totem in your browser" via GitHub Codespaces
+2. **Regression test suite** — permanent validation harness for totem releases
+
+## Repo Structure
+
+```
+src/
+  app/
+    api/users/route.ts    # Violations: process.env, empty catch, console.log, SQL concat
+    api/auth/route.ts     # Violations: raw throw
+    page.tsx              # Clean
+    layout.tsx            # Clean
+  lib/
+    db.ts                 # Violations: process.env, SQL concat
+    todo-fixtures.ts      # Intentional TODO fixtures for Refinement Engine demo
+  middleware/
+    auth.ts               # Violations: empty catch, raw throw, process.env
+.totem/
+  compiled-rules.json     # 40 compiled governance rules
+  lessons/                # 7 lesson files (pg-001 through pg-007)
+  compile-manifest.json   # Compilation state
+  cache/                  # Rule metrics, sync state
+tests/
+  e2e.test.mjs            # E2E test suite
+  setup-baseline.sh       # CI baseline creation (destructive)
+.devcontainer/
+  devcontainer.json       # Codespace demo setup
+```
+
+## Demo Mechanism
+
+The Codespace demo works via an orphan baseline in `postCreateCommand`:
+
+1. `sudo corepack enable && pnpm install` — install deps
+2. `git checkout --orphan demo` — create branch with no history
+3. `git add . && git reset src/app/api/ src/lib/ src/middleware/` — commit clean files only
+4. `git commit -m baseline` — create baseline commit
+5. `git add src/app/api/ src/lib/ src/middleware/` — stage violation files
+
+This makes `totem lint --staged` see the violation files as new staged additions.
+
+## Rule Engines
+
+- `regex` — pattern matching (majority of rules)
+- `ast` — Tree-sitter S-expressions
+- `ast-grep` — structural patterns with YAML configs
+
+## Key Lessons
+
+- **pg-001 through pg-006**: Cover the 5 core violations (env access, empty catch, raw throw, console.log, SQL concat, explicit any)
+- **pg-007**: Intentionally broad TODO marker rule — designed for the Refinement Engine `--upgrade` demo
+
+## Cross-Repo Context
+
+- **totem** (`D:\Dev\totem`) — the main totem monorepo
+- **totem-strategy** (`D:\Dev\totem-strategy`) — governance, ADRs, journal entries
+- Journal entries for this repo live in `totem-strategy/.journal/totem-playground/`

--- a/.claude/docs/contributing.md
+++ b/.claude/docs/contributing.md
@@ -1,0 +1,47 @@
+# Contributing Rules
+
+## Git Conventions
+
+- Never amend commits on feature branches — create new commits.
+- Use `Closes #NNN` in PR descriptions to auto-close issues.
+- Squash merge to main.
+
+## PR Review Bot Protocol
+
+Two bots review PRs. Their interaction models are completely different.
+
+### CodeRabbit (CR)
+
+- Reply inline to any CR comment thread freely.
+- CR reads every reply automatically — no tagging needed.
+- One reply per finding is fine; multiple exchanges are normal.
+
+### Gemini Code Assist (GCA)
+
+- ONE batched top-level PR comment per PR. Never reply inline to individual GCA threads.
+- Every GCA reply MUST contain `@gemini-code-assist` — GCA only sees messages that tag it explicitly.
+- Batch all findings into a single numbered-list response.
+
+> **WARNING:** Inline thread replies to GCA are invisible and silently ignored.
+
+## Intentional Violations
+
+Files in `src/app/api/`, `src/lib/`, and `src/middleware/` contain **intentional** violations:
+
+| # | Violation | Files |
+|---|-----------|-------|
+| 1 | Direct `process.env` access | API routes, middleware, db.ts |
+| 2 | Empty `catch(e) {}` blocks | users/route.ts, auth.ts |
+| 3 | Raw `throw new Error()` | auth/route.ts, auth.ts |
+| 4 | `console.log` in API routes | users/route.ts |
+| 5 | SQL string concatenation | users/route.ts, db.ts |
+
+Do NOT fix these — they are the demo. Do NOT flag them in code review.
+
+## Code Style
+
+- `pnpm` only (never npm/yarn).
+- TypeScript strict mode.
+- No empty catches (except the intentional demo violations).
+- No secrets in config files.
+- **NEVER** use `git push --no-verify` or `totem-ignore` without a ticket.

--- a/.claude/hooks/content-hash.sh
+++ b/.claude/hooks/content-hash.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Content Hash Utility — computes a deterministic hash of tracked source files.
+# Used by both totem review (to stamp) and the PreToolUse hook (to verify).
+# Hashes file CONTENTS, not Git metadata. Immune to commit/amend/rebase.
+
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+cd "$GIT_ROOT"
+
+git ls-files -z '*.ts' '*.tsx' '*.js' '*.jsx' \
+  | tr '\0' '\n' \
+  | grep -v '^$' \
+  | git hash-object --stdin-paths 2>/dev/null \
+  | sha256sum \
+  | cut -d' ' -f1

--- a/.claude/hooks/content-hash.sh
+++ b/.claude/hooks/content-hash.sh
@@ -4,7 +4,7 @@
 # Hashes file CONTENTS, not Git metadata. Immune to commit/amend/rebase.
 
 GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
-cd "$GIT_ROOT"
+cd "$GIT_ROOT" || exit 1
 
 git ls-files -z '*.ts' '*.tsx' '*.js' '*.jsx' \
   | tr '\0' '\n' \

--- a/.claude/hooks/post-compact.sh
+++ b/.claude/hooks/post-compact.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Re-inject critical rules + capability manifest after context compaction
+echo ""
+echo "⚠️  CONTEXT COMPACTED — Critical rules:"
+echo "  1. Run /prepush BEFORE pushing (lint + review)"
+echo "  2. Use Closes #NNN in PR bodies"
+echo "  3. Files in src/app/api/, src/lib/, src/middleware/ are INTENTIONAL violations — do NOT fix"
+echo "  4. Call mcp__totem__search_knowledge before modifying systems"
+
+cat << 'EOF'
+
+📋 Capability Manifest (totem-playground):
+  Commands: lint, review, status, doctor, rule list, lesson list, describe
+  MCP Tools: search_knowledge, add_lesson, verify_execution, describe_project
+  Skills: /preflight, /prepush, /postmerge, /signoff, /review-reply
+  Hooks: PreToolUse (blocks push without review), PostCompact (this manifest)
+  Engines: regex, ast (Tree-sitter), ast-grep
+
+  PR Bot Protocol:
+    CodeRabbit: reply inline freely
+    GCA: ONE batched comment with @gemini-code-assist, never inline
+
+EOF

--- a/.claude/hooks/review-gate.sh
+++ b/.claude/hooks/review-gate.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# PreToolUse hook — Content Hash Gate for git push.
+# Blocks the AI agent from pushing code that hasn't been reviewed.
+# This hook ONLY fires inside Claude Code (PreToolUse boundary).
+# Human terminal pushes are unaffected.
+#
+# Exit 0 = allow, Exit 2 = block.
+
+TOOL_INPUT=$(cat)
+
+# Extract the command
+if command -v jq &>/dev/null; then
+  COMMAND=$(echo "$TOOL_INPUT" | jq -r '.command // empty')
+else
+  COMMAND=$(echo "$TOOL_INPUT" | grep -o '"command":"[^"]*"' | head -1 | sed 's/"command":"//;s/"//')
+fi
+
+# Only gate git push commands
+if [[ ! "$COMMAND" =~ (^|[[:space:]])git[[:space:]]+push([[:space:]]|$) ]]; then
+  exit 0
+fi
+
+# Compute current content hash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CURRENT_HASH=$(bash "$SCRIPT_DIR/content-hash.sh" 2>/dev/null)
+
+if [ -z "$CURRENT_HASH" ]; then
+  # No source files tracked — allow push (nothing to review)
+  exit 0
+fi
+
+# Read stored hash from last review
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+HASH_FILE="$GIT_ROOT/.totem/cache/.reviewed-content-hash"
+
+if [ ! -f "$HASH_FILE" ]; then
+  echo "BLOCKED: No review on record. Run 'pnpm exec totem review' before pushing." >&2
+  exit 2
+fi
+
+REVIEWED_HASH=$(cat "$HASH_FILE" 2>/dev/null | tr -d '[:space:]')
+
+if [ "$CURRENT_HASH" != "$REVIEWED_HASH" ]; then
+  echo "BLOCKED: Source files changed since last review." >&2
+  echo "  Reviewed hash: ${REVIEWED_HASH:0:16}..." >&2
+  echo "  Current hash:  ${CURRENT_HASH:0:16}..." >&2
+  echo "Run 'pnpm exec totem review' to re-validate, then push." >&2
+  exit 2
+fi
+
+# Content hash matches — the code being pushed is exactly what was reviewed.
+exit 0

--- a/.claude/hooks/session-context.js
+++ b/.claude/hooks/session-context.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * SessionStart hook — injects static context about the playground repo.
+ *
+ * stdout → agent context (JSON with additionalContext field)
+ * stderr → diagnostics only
+ */
+
+import { execSync } from 'node:child_process';
+
+function getBranch() {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim();
+  } catch {
+    return 'main';
+  }
+}
+
+function extractTicket(branch) {
+  const match = branch.match(/(\d+)/);
+  return match ? match[1] : null;
+}
+
+function main() {
+  const branch = getBranch();
+  const ticket = extractTicket(branch);
+
+  const lines = [];
+
+  lines.push('── Session Context (totem-playground) ──');
+  lines.push(`Branch: ${branch}`);
+  if (ticket) lines.push(`Ticket: #${ticket}`);
+  lines.push('');
+
+  lines.push('This is the totem-playground repo — a broken Next.js app with');
+  lines.push('5 intentional violations used as a demo and regression test suite.');
+  lines.push('');
+  lines.push('IMPORTANT: Files in src/app/api/, src/lib/, and src/middleware/');
+  lines.push('contain INTENTIONAL violations. Do NOT fix them.');
+  lines.push('');
+
+  lines.push('Knowledge tools available via MCP:');
+  lines.push('  - mcp__totem__search_knowledge: lessons, rules, code context');
+  lines.push('  - mcp__totem__add_lesson: add governance lessons');
+  lines.push('  - mcp__totem__verify_execution: verify against rules');
+  lines.push('  - mcp__totem__describe_project: project overview');
+  lines.push('');
+
+  lines.push('Key commands:');
+  lines.push('  - pnpm exec totem lint [--staged]');
+  lines.push('  - pnpm exec totem review');
+  lines.push('  - pnpm exec totem status');
+  lines.push('  - pnpm exec totem doctor');
+  lines.push('  - pnpm exec totem rule list');
+  lines.push('');
+
+  lines.push('── End Session Context ──');
+
+  const output = JSON.stringify({ additionalContext: lines.join('\n') });
+  process.stdout.write(output);
+}
+
+main();

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,37 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/session-context.js"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/post-compact.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/review-gate.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/postmerge/SKILL.md
+++ b/.claude/skills/postmerge/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: postmerge
+description: Post-merge workflow — extract lessons and sync knowledge
+---
+
+After merging PRs, run the following sequence. Replace `$ARGUMENTS`
+with the merged PR numbers (space-separated, e.g. `51 52`).
+
+1. Extract lessons from the merged PR(s):
+   `pnpm exec totem lesson extract $ARGUMENTS --yes`
+
+2. Sync the semantic index:
+   `pnpm exec totem sync`
+
+3. Compile new rules (local, uses Sonnet):
+   `pnpm exec totem lesson compile`
+
+4. Review newly compiled rules in `.totem/compiled-rules.json`:
+   - Is the pattern over-broad?
+   - Does it reference things that don't exist in this repo?
+   - Is the lesson heading accurate?
+
+5. Stage and commit artifacts:
+   `git add .totem/lessons/ .totem/compiled-rules.json .totem/compile-manifest.json`
+   `git commit -m "chore: totem postmerge lessons for $ARGUMENTS"`
+
+6. Report: how many lessons extracted, rules compiled, any issues found.

--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -10,7 +10,7 @@ Do NOT write code until all gates are cleared.
 
 1. Read the issue on GitHub: `gh issue view $ARGUMENTS --repo mmnto-ai/totem-playground`
 2. Call `mcp__totem__search_knowledge` with a query describing the changes you're about to make.
-3. Check the journal entries in `D:\Dev\totem-strategy\.journal\totem-playground\` for relevant context.
+3. Check the journal entries in the totem-strategy repo (`.journal/totem-playground/`) for relevant context.
 4. Summarize in 3-5 bullets: what the issue asks for, which lessons/rules are relevant, and any constraints.
 
 ## Phase 2 — Scope triage

--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: preflight
+description: Pre-work ritual — search knowledge and plan before coding
+---
+
+Before starting work on issue $ARGUMENTS, execute these phases in order.
+Do NOT write code until all gates are cleared.
+
+## Phase 1 — Context gathering
+
+1. Read the issue on GitHub: `gh issue view $ARGUMENTS --repo mmnto-ai/totem-playground`
+2. Call `mcp__totem__search_knowledge` with a query describing the changes you're about to make.
+3. Check the journal entries in `D:\Dev\totem-strategy\.journal\totem-playground\` for relevant context.
+4. Summarize in 3-5 bullets: what the issue asks for, which lessons/rules are relevant, and any constraints.
+
+## Phase 2 — Scope triage
+
+**Tactical** (skip to implementation) if ALL of:
+- Pure bug fix, config change, or test tightening
+- Touches ≤3 files
+- No new state, types, or failure modes
+
+**Architectural** (draft a plan) if ANY of:
+- Changes demo structure or baseline mechanism
+- Modifies devcontainer setup or CI workflow
+- Touches >3 files or crosses boundaries (tests + src + config)
+- Changes how totem rules are compiled or evaluated
+
+State your triage decision: "Tactical — proceeding" or "Architectural — drafting plan."
+
+## Phase 3 — Plan (architectural only)
+
+Draft a plan covering:
+- **Scope:** What this will do and what it will NOT do
+- **Files to change:** List with expected modifications
+- **Risks:** What could break (demo, CI, Codespace setup)
+- **Test plan:** How to verify
+
+**STOP** and present the plan for user approval before coding.

--- a/.claude/skills/prepush/SKILL.md
+++ b/.claude/skills/prepush/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: prepush
+description: Pre-push checks — lint and review before pushing
+---
+
+Before pushing code:
+
+1. Run `pnpm exec totem lint` — fix any violations before proceeding
+2. Run `pnpm exec totem review` — address any critical findings
+
+After all checks pass, proceed with `git push`. The review command stamps `.reviewed-content-hash` automatically on PASS.
+
+If any step fails, fix the issue and re-run from step 1.

--- a/.claude/skills/review-reply/SKILL.md
+++ b/.claude/skills/review-reply/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: review-reply
+description: Unified PR review triage — fetch, normalize, and batch-action bot comments
+---
+
+Triage PR review comments from all bots for PR $ARGUMENTS.
+
+## Phase 1: Fetch & Categorize
+
+Fetch all bot comments from the PR using the GitHub API:
+
+```bash
+gh api repos/mmnto-ai/totem-playground/pulls/$ARGUMENTS/comments --jq '.[] | "\(.id) | \(.user.login) | \(.body[:120])"'
+gh api repos/mmnto-ai/totem-playground/issues/$ARGUMENTS/comments --jq '.[] | select(.user.login | test("bot")) | "\(.id) | \(.user.login) | \(.body[:120])"'
+```
+
+Categorize findings by blast radius: Security > Architecture > Convention > Nits.
+
+**STOP HERE.** Present the categorized findings to the user and wait for them to specify actions.
+
+## Phase 2: Execute Actions
+
+The user may type individual IDs or bulk actions:
+
+- `fix all security`
+- `defer all nits`
+
+### `fix <numbers | category>`
+
+Mark items as will-fix. Make the code changes.
+
+### `defer <numbers | category> [ticket]`
+
+Reply on the PR acknowledging the deferral:
+
+- **CodeRabbit items:** Reply inline to each thread.
+- **GCA items:** DO NOT reply inline. Batch ALL GCA responses into ONE issue comment with `@gemini-code-assist`.
+
+### `nit <numbers | category>`
+
+Same as defer but reply text is "Acknowledged — nit / by design."
+
+### `done`
+
+Print summary of actions taken and exit.
+
+## CRITICAL: GCA Reply Protocol
+
+**NEVER reply individually to GCA bot comments.** Always batch ALL GCA responses into a single PR-level comment using the issue comments API endpoint (`/issues/{pr}/comments`), tagged with `@gemini-code-assist`.

--- a/.claude/skills/signoff/SKILL.md
+++ b/.claude/skills/signoff/SKILL.md
@@ -5,6 +5,6 @@ description: End-of-session — update memory, clean up, report
 
 End-of-session wrap-up:
 
-1. Update memory files in `~/.claude/projects/D--Dev-totem-playground/memory/` with any new state (decisions made, key discoveries, workflow changes)
+1. Update memory files in the project memory directory with any new state (decisions made, key discoveries, workflow changes)
 2. Clean up stale local branches: `git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D`
 3. Report: what shipped, what's pending, what's next

--- a/.claude/skills/signoff/SKILL.md
+++ b/.claude/skills/signoff/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: signoff
+description: End-of-session — update memory, clean up, report
+---
+
+End-of-session wrap-up:
+
+1. Update memory files in `~/.claude/projects/D--Dev-totem-playground/memory/` with any new state (decisions made, key discoveries, workflow changes)
+2. Clean up stale local branches: `git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D`
+3. Report: what shipped, what's pending, what's next

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ package-lock.json
 .totem/*.jsonl
 .totem/.search-called
 
-.claude/
+.claude/settings.local.json
+.claude/worktrees/
 .env
 .env.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# Totem Playground — Development Rules
+
+## Session Start Protocol (MANDATORY)
+
+Before writing any code or making any changes:
+
+1. Read this file and `.claude/docs/` for context.
+2. Run `pnpm exec totem status` to understand the current state.
+3. **NEVER GUESS.** Before modifying any system, call `mcp__totem__search_knowledge` to load architectural context from the knowledge base.
+4. Do not push speculative fixes. Run `pnpm exec totem lint` locally first.
+
+## Essentials
+
+- **pnpm only** (never npm/yarn). Windows 11 + Git Bash. TypeScript strict mode.
+- `main` is protected. Feature branches + PRs. `Closes #NNN` in PR bodies.
+- Run checks locally before pushing — don't rely on CI to catch issues.
+- This repo has intentional violations in `src/app/api/`, `src/lib/`, and `src/middleware/`. Do NOT fix them — they are the demo.
+
+## Totem Workflow
+
+- **Before coding:** Run `/preflight <issue>`. Create a feature branch.
+- **Before pushing:** Run `/prepush` (lint + review).
+- **After merging:** Run `/postmerge <prs>` to extract lessons.
+- **NEVER** use `git push --no-verify` or `totem-ignore` without a ticket.
+
+## Skills
+
+- `/preflight <issue>` — search + plan before coding
+- `/prepush` — lint + review before push
+- `/postmerge <prs>` — extract lessons after merge
+- `/signoff` — end-of-session memory + cleanup
+- `/review-reply <pr>` — triage and reply to PR bot comments
+
+## PR Bot Protocol
+
+Two bots review PRs — their interaction models are different:
+
+- **CodeRabbit:** Reply inline to each comment freely. No quota.
+- **GCA (Gemini Code Assist):** ONE batched comment in the main PR thread with `@gemini-code-assist`. Never reply inline to GCA threads.
+
+## Context Decay Prevention
+
+After >15 turns of changes: re-read this file, run `pnpm exec totem status`, and re-query the knowledge base for the system you're modifying.
+
+## Detailed Docs
+
+- [Contributing rules](.claude/docs/contributing.md) — git conventions, PR bot protocol, code style
+- [Architecture context](.claude/docs/architecture.md) — repo structure, demo design, rule engines
+- [Agent workflow](.claude/docs/agent-workflow.md) — delegation rules, dispatch templates

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@mmnto/cli": "^1.14.5",
-    "@mmnto/mcp": "^1.14.5",
-    "@mmnto/totem": "^1.14.5",
+    "@mmnto/cli": "^1.14.6",
+    "@mmnto/mcp": "^1.14.6",
+    "@mmnto/totem": "^1.14.6",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "typescript": "^5.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,14 +20,14 @@ dependencies:
 
 devDependencies:
   '@mmnto/cli':
-    specifier: ^1.14.5
-    version: 1.14.5(@google/genai@1.48.0)
+    specifier: ^1.14.6
+    version: 1.14.6(@google/genai@1.48.0)
   '@mmnto/mcp':
-    specifier: ^1.14.5
-    version: 1.14.5(@google/genai@1.48.0)
+    specifier: ^1.14.6
+    version: 1.14.6(@google/genai@1.48.0)
   '@mmnto/totem':
-    specifier: ^1.14.5
-    version: 1.14.5(@google/genai@1.48.0)
+    specifier: ^1.14.6
+    version: 1.14.6(@google/genai@1.48.0)
   '@types/node':
     specifier: ^22.0.0
     version: 22.19.17
@@ -508,8 +508,8 @@ packages:
       '@lancedb/lancedb-win32-x64-msvc': 0.26.2
     dev: true
 
-  /@mmnto/cli@1.14.5(@google/genai@1.48.0):
-    resolution: {integrity: sha512-U2qEFi+hIduIwcJL+VCnRx+2NQFzowiVcYNsA0gK+kCJkoZZRasCLUMRB0dfHInh59SOYgorZ5fpHOUG94fdoQ==}
+  /@mmnto/cli@1.14.6(@google/genai@1.48.0):
+    resolution: {integrity: sha512-XO4mAK3bJ5/XKJOwNwUnSRvEmdcBI2UCXfbvS2VJnujAW0rEKhnSo/RsafGzO/ix/xEIPzNOUogzhpXwKxFylw==}
     hasBin: true
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.50.0'
@@ -525,7 +525,7 @@ packages:
     dependencies:
       '@clack/prompts': 1.2.0
       '@google/genai': 1.48.0
-      '@mmnto/totem': 1.14.5(@google/genai@1.48.0)
+      '@mmnto/totem': 1.14.6(@google/genai@1.48.0)
       commander: 13.1.0
       dotenv: 16.6.1
       jiti: 2.6.1
@@ -541,11 +541,11 @@ packages:
       - ws
     dev: true
 
-  /@mmnto/mcp@1.14.5(@google/genai@1.48.0):
-    resolution: {integrity: sha512-SDMmeMg4FvY9k8b9094RE4bVWO5DVqhT4RgTnLH8kKUl3pmvejOj0cr9UMwZzPSGQ9djG80iqOzZKB/T7SQEiw==}
+  /@mmnto/mcp@1.14.6(@google/genai@1.48.0):
+    resolution: {integrity: sha512-yYNZcdZJishnlrtsiub3j1EEY7/WHIWz6OexOUIYr4VQQ00+R6mSlTCcBZvMm2G4czoGQZiyJgDKWMLRdtoNYQ==}
     hasBin: true
     dependencies:
-      '@mmnto/totem': 1.14.5(@google/genai@1.48.0)
+      '@mmnto/totem': 1.14.6(@google/genai@1.48.0)
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       dotenv: 16.6.1
       jiti: 2.6.1
@@ -559,8 +559,8 @@ packages:
       - ws
     dev: true
 
-  /@mmnto/totem@1.14.5(@google/genai@1.48.0):
-    resolution: {integrity: sha512-KvZMybythPPi2PzqRXknIopZTAfpcc4xxYE/IOfZpaGOFfD0VSYreHfjQWcKP70GbUL5zqoigqlqarn/41Efsw==}
+  /@mmnto/totem@1.14.6(@google/genai@1.48.0):
+    resolution: {integrity: sha512-XP/X37Z0fNIyiu7LlKrpXz50ulMPWiGsOv0Ysrrfv6VZRuk2AU7Ou0n2wXzvEWdkQyWfiDgg8T9f8AhSWl2CsA==}
     peerDependencies:
       '@google/genai': '>=1.0.0'
     peerDependenciesMeta:


### PR DESCRIPTION
## Summary
- Add the complete totem-powered Claude Code harness, adapted from the main totem repo:
  - `CLAUDE.md` with playground-specific development rules
  - 4 hooks: SessionStart (context injection), PostCompact (capability manifest), PreToolUse (review gate), content-hash
  - 5 skills: `/preflight`, `/prepush`, `/postmerge`, `/signoff`, `/review-reply`
  - 3 docs: contributing, architecture, agent-workflow
- Update `.gitignore` to track `.claude/` harness files (only `settings.local.json` and `worktrees/` remain ignored)
- Bump `@mmnto/cli`, `@mmnto/mcp`, `@mmnto/totem` from 1.14.5 to 1.14.6

## Test plan
- [ ] Verify hooks load on session start
- [ ] Verify `/prepush` skill runs lint + review
- [ ] Verify review gate blocks push without `totem review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive developer docs: architecture, contributing, agent workflow, session/skill guides (preflight, prepush, postmerge, review-reply, signoff) and a top-level project workflow guide.

* **Chores**
  * Added automation hooks and pre-push gating to enforce review/lint workflows and session context checks.
  * Updated development tooling to the latest patch versions.
  * Narrowed ignore rules to allow tracking of new development config files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->