### PR TITLE
docs: refresh version labels for totem 1.15.0 shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,17 +163,16 @@ Expected output:
       b0db9b6d5e5475c1 (regex, 100% non-code, 6 matches),
       cd5e47a67dc1ca0b (regex, 85% non-code, 20 matches),
       98977f94c7e116c2 (regex, 71% non-code, 14 matches)
-    → Run `totem compile --upgrade <hash>` to re-compile through
+    → Run `totem lesson compile --upgrade <hash>` to re-compile through
       Claude Sonnet with telemetry guidance.
 ```
 
 > **Note:** The specific candidates, hashes, and percentages above will vary
-> based on the telemetry accumulated from your own lint runs in step 1 — the
-> block is illustrative of a seeded playground's typical output. Also note
-> that doctor's `→ Run` hint shows the deprecated `totem compile --upgrade`
-> form rather than the canonical `totem lesson compile --upgrade` used in
-> step 3 below; this is a known quirk in 1.14.0 tracked upstream as
-> [mmnto-ai/totem#1309](https://github.com/mmnto-ai/totem/issues/1309).
+> based on the telemetry accumulated from your own lint runs in step 1. The
+> block is illustrative of a seeded playground's typical output. The
+> `→ Run` hint emits the canonical `totem lesson compile --upgrade` form,
+> matching step 3 below ([mmnto-ai/totem#1309](https://github.com/mmnto-ai/totem/issues/1309)
+> resolved this earlier 1.14.0 alias drift).
 
 The doctor reads `rule-metrics.json`, computes each regex rule's non-code ratio as `(strings + comments + regex) / total_classified`, and flags anything above the `NON_CODE_THRESHOLD` (20%). The seeded `cd5e47a67dc1ca0b` rule fires ~85% in non-code contexts — matching TODO mentions in strings, comments, and regex literals from `todo-fixtures.ts`. The baseline `b0db9b6d5e5475c1` rule ("Silent failures and TODO placeholders") shows up as an incidental candidate because it, too, matches comment-context TODOs. A third candidate, `98977f94c7e116c2` ("Scaffolding scripts failing to respect existing .git states"), appears because its `\bgit\s+init\b` pattern matches the `execSync('git init', ...)` calls in `tests/e2e.test.mjs` that spin up isolated temp git repositories for testing, along with the inline comments explaining why the plain form (without `-b main`) is used for Git < 2.28 compatibility. Those comment-context hits drive the non-code ratio above doctor's 20% threshold.
 

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@mmnto/cli": "^1.14.6",
-    "@mmnto/mcp": "^1.14.6",
-    "@mmnto/totem": "^1.14.6",
+    "@mmnto/cli": "^1.15.0",
+    "@mmnto/mcp": "^1.15.0",
+    "@mmnto/totem": "^1.15.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "typescript": "^5.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,14 +20,14 @@ dependencies:
 
 devDependencies:
   '@mmnto/cli':
-    specifier: ^1.14.6
-    version: 1.14.6(@google/genai@1.48.0)
+    specifier: ^1.15.0
+    version: 1.15.0(@google/genai@1.48.0)
   '@mmnto/mcp':
-    specifier: ^1.14.6
-    version: 1.14.6(@google/genai@1.48.0)
+    specifier: ^1.15.0
+    version: 1.15.0(@google/genai@1.48.0)
   '@mmnto/totem':
-    specifier: ^1.14.6
-    version: 1.14.6(@google/genai@1.48.0)
+    specifier: ^1.15.0
+    version: 1.15.0(@google/genai@1.48.0)
   '@types/node':
     specifier: ^22.0.0
     version: 22.19.17
@@ -492,6 +492,7 @@ packages:
   /@lancedb/lancedb@0.26.2(apache-arrow@17.0.0):
     resolution: {integrity: sha512-umk4WMCTwJntLquwvUbpqE+TXREolcQVL9MHcxr8EhRjsha88+ATJ4QuS/hpyiE1CG3R/XcgrMgJAGkziPC/gA==}
     engines: {node: '>= 18'}
+    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
@@ -508,8 +509,8 @@ packages:
       '@lancedb/lancedb-win32-x64-msvc': 0.26.2
     dev: true
 
-  /@mmnto/cli@1.14.6(@google/genai@1.48.0):
-    resolution: {integrity: sha512-XO4mAK3bJ5/XKJOwNwUnSRvEmdcBI2UCXfbvS2VJnujAW0rEKhnSo/RsafGzO/ix/xEIPzNOUogzhpXwKxFylw==}
+  /@mmnto/cli@1.15.0(@google/genai@1.48.0):
+    resolution: {integrity: sha512-v0ftaPT0pArqJ0u70Ty1iqPWlvj7gCaXsCczEzY9tvo+RWjMQIDdjvRMFqUSdP7uKofxhxbKaJeoHSq8KFgDpg==}
     hasBin: true
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.50.0'
@@ -525,7 +526,7 @@ packages:
     dependencies:
       '@clack/prompts': 1.2.0
       '@google/genai': 1.48.0
-      '@mmnto/totem': 1.14.6(@google/genai@1.48.0)
+      '@mmnto/totem': 1.15.0(@google/genai@1.48.0)
       commander: 13.1.0
       dotenv: 16.6.1
       jiti: 2.6.1
@@ -541,11 +542,11 @@ packages:
       - ws
     dev: true
 
-  /@mmnto/mcp@1.14.6(@google/genai@1.48.0):
-    resolution: {integrity: sha512-yYNZcdZJishnlrtsiub3j1EEY7/WHIWz6OexOUIYr4VQQ00+R6mSlTCcBZvMm2G4czoGQZiyJgDKWMLRdtoNYQ==}
+  /@mmnto/mcp@1.15.0(@google/genai@1.48.0):
+    resolution: {integrity: sha512-oZJknmSXuCi5FMXEOXFXg2XU8SKvfHKavNaeFuIc4Yz0UFm8QKFcP88W1GzBIDghilRYlshWerLBMQ1IFRrgcA==}
     hasBin: true
     dependencies:
-      '@mmnto/totem': 1.14.6(@google/genai@1.48.0)
+      '@mmnto/totem': 1.15.0(@google/genai@1.48.0)
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       dotenv: 16.6.1
       jiti: 2.6.1
@@ -559,8 +560,8 @@ packages:
       - ws
     dev: true
 
-  /@mmnto/totem@1.14.6(@google/genai@1.48.0):
-    resolution: {integrity: sha512-XP/X37Z0fNIyiu7LlKrpXz50ulMPWiGsOv0Ysrrfv6VZRuk2AU7Ou0n2wXzvEWdkQyWfiDgg8T9f8AhSWl2CsA==}
+  /@mmnto/totem@1.15.0(@google/genai@1.48.0):
+    resolution: {integrity: sha512-QrqAl/dTuqeTQqCUi738E5S/nGYC47/1Xjfuj5yrJ3l9w8WP+5L5p/sDPrLw/NECM0XDwEIppSafDOgzt61U4g==}
     peerDependencies:
       '@google/genai': '>=1.0.0'
     peerDependenciesMeta:

--- a/tests/e2e.test.mjs
+++ b/tests/e2e.test.mjs
@@ -554,11 +554,10 @@ describe('totem doctor upgrade candidate detection', () => {
   it('prints the --upgrade remediation hint', () => {
     const { output } = totemMerged(['doctor']);
     // Accepts both `totem compile --upgrade` (deprecated alias) and
-    // `totem lesson compile --upgrade` (the 1.14.0 canonical form).
-    // As of 1.14.0, upstream `totem doctor` still emits the deprecated
-    // alias in its hint string — when that's fixed upstream, this regex
-    // can be tightened to require the `lesson ` prefix. See #39 and the
-    // upstream mmnto-ai/totem companion ticket.
+    // `totem lesson compile --upgrade` (the canonical form).
+    // The canonical form has been the default emitted by `totem doctor`
+    // since the fix for mmnto-ai/totem#1309 landed. The regex stays
+    // permissive so older pinned versions still pass. See #39.
     assert.match(output, /totem (?:lesson )?compile --upgrade/,
       'doctor should suggest the --upgrade command (either form)');
   });


### PR DESCRIPTION
## Summary

Bumps the playground onto totem 1.15.0 and refreshes a couple of stale 1.14.0-era labels that have outlived their cause.

- `package.json`: `@mmnto/cli`, `@mmnto/mcp`, `@mmnto/totem` from `^1.14.6` to `^1.15.0`. Lockfile regenerated.
- `README.md`: Refinement Engine section's `Expected output:` block now shows the canonical `totem lesson compile --upgrade` form that doctor emits today, and the variance-caveat note no longer flags the alias drift as a current quirk. The mmnto-ai/totem#1309 fix landed before 1.14.6 and is confirmed on 1.15.0.
- `tests/e2e.test.mjs`: comment block on the doctor-hint test reframed to reflect that the fix has shipped. The regex stays permissive (`/totem (?:lesson )?compile --upgrade/`) so projects pinned to older versions still pass.

## Scope discipline

Strictly label accuracy. No fixture changes, no `compiled-rules.json` mutations, no lessons touched. The trap corpus is unchanged.

## Test plan

- [x] `pnpm exec totem --version` reports 1.15.0
- [x] `pnpm exec totem lint` passes (40 rules, 0 violations on a clean checkout)
- [x] `pnpm exec totem doctor` emits the canonical `totem lesson compile --upgrade <hash>` form, matching the updated README
- [x] `pnpm exec totem review` passes (Shield comment-only verdict on the test edit)

## Out of scope

- `@totem/pack-agent-security` is not yet referenced in this README. The pack ships workspace-private in 1.15.0 pending Sigstore signing (mmnto-ai/totem#1492 blocks mmnto-ai/totem#1609). Adding a Pack Distribution section is feature work and lives in a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README examples to reflect the canonical CLI command syntax for upgrade operations.

* **Tests**
  * Updated test assertions to properly validate current command output format and backwards compatibility behavior.

* **Chores**
  * Updated development dependencies to version 1.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->