### PR TITLE
docs: add capture version marker to Expected output blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Each matching line is classified by its AST context (code, string, comment, rege
 totem doctor
 ```
 
-Expected output:
+Expected output (captured on Totem 1.15.0):
 
 ```text
 [Totem] Running diagnostics...
@@ -182,7 +182,7 @@ The doctor reads `rule-metrics.json`, computes each regex rule's non-code ratio 
 totem lesson compile --upgrade cd5e47a67dc1ca0b
 ```
 
-Expected output:
+Expected output (captured on Totem 1.15.0):
 
 ```text
 [Compile] Found 66 lessons


### PR DESCRIPTION
## Summary

Applies the CodeRabbit nit from #56 that was deferred at merge time. Adds a "captured on Totem 1.15.0" marker to both `Expected output:` blocks in the Refinement Engine walkthrough.

The marker makes future output-drift audits faster without changing the walkthrough flow or the verbatim CLI output.

## Changes

- `README.md` line 150: `Expected output:` → `Expected output (captured on Totem 1.15.0):`
- `README.md` line 185: same treatment on the `totem lesson compile --upgrade` block

## Scope

Two-line wording change. No fixture, no compiled-rules, no lessons touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README examples with concrete captured output results for command demonstrations, including explicit version annotations for enhanced clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->